### PR TITLE
Correct postgresql upstream group and version spec

### DIFF
--- a/org.ops4j.pax.tipi.org.postgresql/pom.xml
+++ b/org.ops4j.pax.tipi.org.postgresql/pom.xml
@@ -28,9 +28,9 @@
     </scm>
 
     <properties>
-        <tipi.orig.groupId>postgresql</tipi.orig.groupId>
+        <tipi.orig.groupId>org.postgresql</tipi.orig.groupId>
         <tipi.orig.artifactId>postgresql</tipi.orig.artifactId>
-        <tipi.orig.version>9.2-1002.jdbc4</tipi.orig.version>
+        <tipi.orig.version>9.2-1002-jdbc4</tipi.orig.version>
         <tipi.osgi.export>
            org.postgresql.*;version="${project.version}"
         </tipi.osgi.export>


### PR DESCRIPTION
Corrected the upstream group and versions for the postgresql driver. See:

http://search.maven.org/#search%7Cga%7C1%7Cpostgresql
