### PR TITLE
[PAXTIPI-47] Add Tomcat 8.0.46

### DIFF
--- a/tomcat-embed-core-8.0.46/pom.xml
+++ b/tomcat-embed-core-8.0.46/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.ops4j.pax.tipi</groupId>
+        <artifactId>tipi-master</artifactId>
+        <version>1.4.0</version>
+        <relativePath>../tipi-master</relativePath>
+    </parent>
+
+    <artifactId>org.ops4j.pax.tipi.tomcat-embed-core</artifactId>
+    <version>8.0.46.1-SNAPSHOT</version>
+    <packaging>bundle</packaging>
+    <name>OPS4J Pax Tipi - ${tipi.orig.artifactId}</name>
+    <description>This OSGi bundle wraps ${tipi.orig.artifactId}-${tipi.orig.version}</description>
+
+    <!-- This section may seem redundant, but if you delete it, maven-release-plugin will compute an incorrect URL. -->
+    <scm>
+        <connection>scm:git:git@github.com:ops4j/org.ops4j.pax.tipi.git</connection>
+        <developerConnection>scm:git:git@github.com:ops4j/org.ops4j.pax.tipi.git</developerConnection>
+        <url>git@github.com:ops4j/org.ops4j.pax.tipi.git</url>
+        <tag>HEAD</tag>
+    </scm>
+
+    <properties>
+        <servlet.version>3.1.0</servlet.version>
+        <tipi.orig.groupId>org.apache.tomcat.embed</tipi.orig.groupId>
+        <tipi.orig.artifactId>tomcat-embed-core</tipi.orig.artifactId>
+        <tipi.orig.version>8.0.46</tipi.orig.version>
+        <tipi.osgi.export>
+            org.apache.catalina*;version=${tipi.orig.version},
+            org.apache.coyote*;version=${tipi.orig.version},
+            org.apache.naming*;version=${tipi.orig.version},
+            org.apache.tomcat*;version=${tipi.orig.version}
+        </tipi.osgi.export>
+        <tipi.osgi.import>
+            javax.servlet;version=${servlet.version},
+            javax.servlet.http;version=${servlet.version},
+            javax.servlet.annotation;version=${servlet.version},
+            javax.servlet.descriptor;version=${servlet.version},
+            javax.servlet.jsp.tagext; version="2.3.1",
+            org.apache.juli.logging,
+            *
+        </tipi.osgi.import>
+        <tipi.osgi.embed.dependency>
+            tomcat-embed-core;inline=org/apache/**|META-INF/**,
+        </tipi.osgi.embed.dependency>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${tipi.orig.groupId}</groupId>
+            <artifactId>${tipi.orig.artifactId}</artifactId>
+            <version>${tipi.orig.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tomcat-embed-websocket-8.0.46/pom.xml
+++ b/tomcat-embed-websocket-8.0.46/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.ops4j.pax.tipi</groupId>
+        <artifactId>tipi-master</artifactId>
+        <version>1.4.0</version>
+        <relativePath>../tipi-master</relativePath>
+    </parent>
+
+    <artifactId>org.ops4j.pax.tipi.tomcat-embed-websocket</artifactId>
+    <version>8.0.46.1-SNAPSHOT</version>
+    <packaging>bundle</packaging>
+    <name>OPS4J Pax Tipi - ${tipi.orig.artifactId}</name>
+    <description>This OSGi bundle wraps ${tipi.orig.artifactId}-${tipi.orig.version}</description>
+
+    <!-- This section may seem redundant, but if you delete it, maven-release-plugin will compute an incorrect URL. -->
+    <scm>
+        <connection>scm:git:git@github.com:ops4j/org.ops4j.pax.tipi.git</connection>
+        <developerConnection>scm:git:git@github.com:ops4j/org.ops4j.pax.tipi.git</developerConnection>
+        <url>git@github.com:ops4j/org.ops4j.pax.tipi.git</url>
+        <tag>HEAD</tag>
+    </scm>
+
+    <properties>
+        <tipi.orig.groupId>org.apache.tomcat.embed</tipi.orig.groupId>
+        <tipi.orig.artifactId>tomcat-embed-websocket</tipi.orig.artifactId>
+        <tipi.orig.version>8.0.46</tipi.orig.version>
+        <tipi.osgi.export>
+            org.apache.tomcat.websocket*;version=${tipi.orig.version}
+        </tipi.osgi.export>
+        <tipi.osgi.import>*</tipi.osgi.import>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${tipi.orig.groupId}</groupId>
+            <artifactId>${tipi.orig.artifactId}</artifactId>
+            <version>${tipi.orig.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>org.ops4j.pax.tipi.tomcat-embed-core</artifactId>
+            <version>8.0.46.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
This pull request adds wrapper bundles for version 8.0.46 of tomcat-embed-core and tomcat-embed-websocket.

There is no wrapper bundle for tomcat-embed-juli. tomcat-embed-core does already contain the packages contained in there. I have added an unversioned import for org.apache,juli.logging to the tomcat-embed-core bundle. This way tomcat-embed-core will use the org.apache.juli.logging implementation from pax-logging if it is there and provide its own one if it is not there.

There is also no wrapper bundle for tomcat-embed-jasper. This jar is wrapped within pax-web-jsp (and needs to be handled separately there).